### PR TITLE
Restore ability for custom package installation via texlive.packages file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,20 +6,13 @@
 
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 CONF_DIR="$BIN_DIR/../conf"
 
 TEXLIVE_REPOSITORY="ftp://tug.org/historic/systems/texlive/2017/tlnet-final"
-
-# TODO: remove this in future versions.
-# This is only kept for backwards support
-if [ -f "$BUILD_DIR/.texlive-repository" ]; then
-    TEXLIVE_REPOSITORY=$(cat "$BUILD_DIR/.texlive-repository")
-fi
-
-# Optional: use custom path to texlive installer
-if [ -f "$BUILD_DIR/texlive.repository" ]; then
-    TEXLIVE_REPOSITORY=$(cat "$BUILD_DIR/texlive.repository")
+if [ -f $ENV_DIR/TEXLIVE_REPOSITORY ]; then
+    TEXLIVE_REPOSITORY=$(cat $ENV_DIR/TEXLIVE_REPOSITORY)
 fi
 
 TEXLIVE_INSTALLER_URL="$TEXLIVE_REPOSITORY/install-tl-unx.tar.gz"
@@ -41,7 +34,10 @@ mkdir -p "$TEXLIVE_HOME"
 mkdir -p "$TEXLIVE_CACHE"
 mkdir -p "$(dirname "$PROFILE_D")"
 
-build-step "TEXLIVE_INATALLER_URL: $TEXLIVE_INSTALLER_URL"
+build-step "BIN_DIR: $BIN_DIR"
+build-step "BUILD_DIR: $BUILD_DIR"
+build-step "TEXLIVE_REPOSITORY: $TEXLIVE_REPOSITORY"
+build-step "TEXLIVE_INSTALLER_URL: $TEXLIVE_INSTALLER_URL"
 build-step "TEXLIVE_HOME: $TEXLIVE_HOME"
 build-step "TEXLIVE_CACHE: $TEXLIVE_CACHE"
 build-step "TEXMF_LOCAL: $TEXMF_LOCAL"

--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,31 @@ if [ ! "$(which latex)" ]; then
     exit 0
 fi
 
+if wget -q $TEXLIVE_REPOSITORY/README.md
+then
+  # the repository is responsive
+  build-step "Updating TeX Live..."
+
+  tlmgr option repository "$TEXLIVE_REPOSITORY"
+
+  build-step "TeX Live repository set to $TEXLIVE_REPOSITORY"
+
+  tlmgr update --self
+
+  # install user-provided-packages
+  if [ -f "$BUILD_DIR/texlive.packages" ]; then
+      build-step "Installing custom packages..."
+      # shellcheck disable=SC2046
+      tlmgr install $(cat "$BUILD_DIR/texlive.packages")
+  fi
+
+  build-step "Updating installed packages..."
+  tlmgr update --all
+else
+  build-warn "Unable to access $TEXLIVE_REPOSITORY; falling back on cached installation"
+  exit 0
+fi
+
 build-step "TeX Live installation successful!"
 build-step "Cleaning up temporary files..."
 # Make sure the cache is empty


### PR DESCRIPTION
Buildpack reads `texlive.packages` file committed at the app root, and will install any TeXLive package listed there.

I also added the ability to override the TeXLive repo URL via a Heroku environment variable named `TEXLIVE_REPOSITORY`, which will eventually allow using CTAN mirrors of the TeXLive repo; however, the installation is currently hard-coded to use the 2017 version, which is apparently not mirrored, so we're still rolling the dice with the tug.org site. Ideally, the default repo URL would be set to the generic CTAN mirror, i.e. `http://mirror.ctan.org/systems/texlive/tlnet`, which would ensure maximum download speed and the latest version of TeXLive.