### PR TITLE
add TK colors

### DIFF
--- a/conf/Tikz-IM.sty
+++ b/conf/Tikz-IM.sty
@@ -416,6 +416,12 @@
     \definecolor{PRed}{RGB}{251,0,6}
     \definecolor{POrange}{RGB}{253,134,9}
 
+    % TK colors APRIL 2025 (for TK only)
+    \definecolor{Brown}{RGB}{139,94,60}
+    \definecolor{LBrown}{RGB}{193,154,107}
+    \definecolor{Purple}{RGB}{133,64,213}
+    \definecolor{LPurple}{RGB}{199,168,240}
+
     \newcommand{\FunctionMachine}[3]{
 
     \node (a) at (0,0) [draw,very thick,inner sep=3pt,minimum height=.7in,text width=2cm,text centered] {#2};


### PR DESCRIPTION
Add new TK colors

This was tested by: 

Set new 
```
buildpack heroku buildpacks:set [https://github.com/illustrativemathematics/heroku-buildpack-tex.git\#mtorres/pe-2762-new-tikz-colors-for-sty-files](https://github.com/illustrativemathematics/heroku-buildpack-tex.git%5C#mtorres/pe-2762-new-tikz-colors-for-sty-files) --app qa-cms-im 
```

delete old one via heroku ui 

deploy main to qa



checking if the new colors are there: 
```
heroku run bash --app qa-cms-im
grep -i definecolor /app/.texlive/texmf-local/tex/latex/local/Tikz-IM.sty
```

Should show: 

    \definecolor{Yellow}{RGB}{255,184,28}
    \definecolor{Green}{RGB}{67,176,42}
    \definecolor{Blue}{RGB}{0,149,200}
    \definecolor{Red}{RGB}{224,60,49}
    \definecolor{LYellow}{RGB}{255,215,145}
    \definecolor{LGreen}{RGB}{170,215,165}
    \definecolor{LBlue}{RGB}{125,206,235}

Create tikz file with new colors 
```
\documentclass{IM}
\begin{document}
\begin{tikzpicture}
  \draw[fill=LPurple] (0,0) circle (1cm);
  \draw[fill=Brown] (2.5,0) circle (1cm);
  \draw[fill=LBrown] (5,0) circle (1cm);
  \draw[fill=Purple] (7.5,0) circle (1cm);
\end{tikzpicture}
\end{document}
```

<img width="1512" alt="Screenshot 2025-04-23 at 9 09 12 AM" src="https://github.com/user-attachments/assets/7a6b38c7-dcfc-4060-84ae-dd335d0dcfdf" />
